### PR TITLE
Adding port to config

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -1,6 +1,6 @@
 define({
 	// This css path is used as a default by the Kalei project it self.
-	css_path: window.location.protocol + '//' + window.location.hostname + '/' + window.location.pathname +  '/css/',
+	css_path: window.location.protocol + '//' + window.location.hostname + ':' + window.location.port + '/' + window.location.pathname +  '/css/',
 
 	// You can configure any path by just deleteing the one above and uncommenting the one below to point at your css directory
 	//css_path: 'http://localhost/repos/budder-client/css/',


### PR DESCRIPTION
I sometimes have port 80 allocated to another app, so I included window.location.port to the default config.
