### PR TITLE
Update github-buttons url to ghbtns.com

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -3,9 +3,9 @@
 
 This project aims at making sure your style sheets are fully documented whilst being synchronized with your webpages styles. To do this it actually uses your live stylesheets in so that at anytime you can review how your styleguide looks.
 
-<iframe src="http://markdotto.github.com/github-buttons/github-btn.html?user=thomasdavis&repo=kalei&type=watch&count=true&size=large" allowtransparency="true" frameborder="0" scrolling="0" width="170px" height="30px"></iframe>
+<iframe src="http://ghbtns.com//github-btn.html?user=thomasdavis&repo=kalei&type=watch&count=true&size=large" allowtransparency="true" frameborder="0" scrolling="0" width="170px" height="30px"></iframe>
 
-<iframe src="http://markdotto.github.com/github-buttons/github-btn.html?user=thomasdavis&repo=kalei&type=fork&count=true&size=large" allowtransparency="true" frameborder="0" scrolling="0" width="146px" height="30px"></iframe>
+<iframe src="http://ghbtns.com//github-btn.html?user=thomasdavis&repo=kalei&type=fork&count=true&size=large" allowtransparency="true" frameborder="0" scrolling="0" width="146px" height="30px"></iframe>
 
 
 ## Main goals and benefits


### PR DESCRIPTION
Kalei homepage and project both complain about iframes not being
allowed. This appears to be due to out-of-date references to
markdotto.github.com/github-buttons. Updating these appears to fix the
behavior.
