### PR TITLE
Upgrade to marked v0.2.8 in order to support markdown tables

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -1,6 +1,6 @@
 define({
 	// This css path is used as a default by the Kalei project it self.
-	css_path: window.location.protocol + '//' + window.location.hostname + (window.location.port === '' ? '' : ':'+ window.location.port) + window.location.pathname +  'css/styles.css'
+	css_path: window.location.protocol + '//' + window.location.hostname + (window.location.port === '' ? '' : ':'+ window.location.port) + window.location.pathname +  'css/styles.css',
 	// You can configure any path by just deleteing the one above and uncommenting the one below to point at your css directory
 	//css_path: 'http://localhost/css/styles.css',
 	

--- a/js/config.js
+++ b/js/config.js
@@ -3,6 +3,11 @@ define({
 	css_path: window.location.protocol + '//' + window.location.hostname + (window.location.port === '' ? '' : ':'+ window.location.port) + window.location.pathname +  'css/styles.css'
 	// You can configure any path by just deleteing the one above and uncommenting the one below to point at your css directory
 	//css_path: 'http://localhost/css/styles.css',
+	
+	// You can optionally set configuration for marked.js
+	marked_options: {
+		tables: true
+	}
 
 	//disqus_shortname: 'kaleistyleguide'
 });

--- a/js/libs/marked/marked.js
+++ b/js/libs/marked/marked.js
@@ -1,8 +1,9 @@
 /**
- * marked - A markdown parser (https://github.com/chjj/marked)
- * Copyright (c) 2011-2012, Christopher Jeffrey. (MIT Licensed)
+ * marked - a markdown parser
+ * Copyright (c) 2011-2013, Christopher Jeffrey. (MIT Licensed)
+ * https://github.com/chjj/marked
  */
-define(function (){
+
 ;(function() {
 
 /**
@@ -15,12 +16,14 @@ var block = {
   fences: noop,
   hr: /^( *[-*_]){3,} *(?:\n+|$)/,
   heading: /^ *(#{1,6}) *([^\n]+?) *#* *(?:\n+|$)/,
+  nptable: noop,
   lheading: /^([^\n]+)\n *(=|-){3,} *\n*/,
   blockquote: /^( *>[^\n]+(\n[^\n]+)*\n*)+/,
-  list: /^( *)(bull) [^\0]+?(?:hr|\n{2,}(?! )(?!\1bull )\n*|\s*$)/,
+  list: /^( *)(bull) [\s\S]+?(?:hr|\n{2,}(?! )(?!\1bull )\n*|\s*$)/,
   html: /^ *(?:comment|closed|closing) *(?:\n{2,}|\s*$)/,
-  def: /^ *\[([^\]]+)\]: *([^\s]+)(?: +["(]([^\n]+)[")])? *(?:\n+|$)/,
-  paragraph: /^([^\n]+\n?(?!body))+\n*/,
+  def: /^ *\[([^\]]+)\]: *<?([^\s>]+)>?(?: +["(]([^\n]+)[")])? *(?:\n+|$)/,
+  table: noop,
+  paragraph: /^((?:[^\n]+\n?(?!hr|heading|lheading|blockquote|tag|def))+)\n*/,
   text: /^[^\n]+/
 };
 
@@ -35,68 +38,114 @@ block.list = replace(block.list)
   ('hr', /\n+(?=(?: *[-*_]){3,} *(?:\n+|$))/)
   ();
 
+block._tag = '(?!(?:'
+  + 'a|em|strong|small|s|cite|q|dfn|abbr|data|time|code'
+  + '|var|samp|kbd|sub|sup|i|b|u|mark|ruby|rt|rp|bdi|bdo'
+  + '|span|br|wbr|ins|del|img)\\b)\\w+(?!:/|@)\\b';
+
 block.html = replace(block.html)
-  ('comment', /<!--[^\0]*?-->/)
-  ('closed', /<(tag)[^\0]+?<\/\1>/)
-  ('closing', /<tag(?!:\/|@)\b(?:"[^"]*"|'[^']*'|[^'">])*?>/)
-  (/tag/g, tag())
+  ('comment', /<!--[\s\S]*?-->/)
+  ('closed', /<(tag)[\s\S]+?<\/\1>/)
+  ('closing', /<tag(?:"[^"]*"|'[^']*'|[^'">])*?>/)
+  (/tag/g, block._tag)
   ();
 
-block.paragraph = (function() {
-  var paragraph = block.paragraph.source
-    , body = [];
+block.paragraph = replace(block.paragraph)
+  ('hr', block.hr)
+  ('heading', block.heading)
+  ('lheading', block.lheading)
+  ('blockquote', block.blockquote)
+  ('tag', '<' + block._tag)
+  ('def', block.def)
+  ();
 
-  (function push(rule) {
-    rule = block[rule] ? block[rule].source : rule;
-    body.push(rule.replace(/(^|[^\[])\^/g, '$1'));
-    return push;
-  })
-  ('hr')
-  ('heading')
-  ('lheading')
-  ('blockquote')
-  ('<' + tag())
-  ('def');
+/**
+ * Normal Block Grammar
+ */
 
-  return new
-    RegExp(paragraph.replace('body', body.join('|')));
-})();
+block.normal = merge({}, block);
 
-block.normal = {
-  fences: block.fences,
-  paragraph: block.paragraph
-};
+/**
+ * GFM Block Grammar
+ */
 
-block.gfm = {
-  fences: /^ *``` *(\w+)? *\n([^\0]+?)\s*``` *(?:\n+|$)/,
+block.gfm = merge({}, block.normal, {
+  fences: /^ *(`{3,}|~{3,}) *(\w+)? *\n([\s\S]+?)\s*\1 *(?:\n+|$)/,
   paragraph: /^/
-};
+});
 
 block.gfm.paragraph = replace(block.paragraph)
-  ('(?!', '(?!' + block.gfm.fences.source.replace(/(^|[^\[])\^/g, '$1') + '|')
+  ('(?!', '(?!' + block.gfm.fences.source.replace('\\1', '\\2') + '|')
   ();
+
+/**
+ * GFM + Tables Block Grammar
+ */
+
+block.tables = merge({}, block.gfm, {
+  nptable: /^ *(\S.*\|.*)\n *([-:]+ *\|[-| :]*)\n((?:.*\|.*(?:\n|$))*)\n*/,
+  table: /^ *\|(.+)\n *\|( *[-:]+[-| :]*)\n((?: *\|.*(?:\n|$))*)\n*/
+});
 
 /**
  * Block Lexer
  */
 
-block.lexer = function(src) {
-  var tokens = [];
+function Lexer(options) {
+  this.tokens = [];
+  this.tokens.links = {};
+  this.options = options || marked.defaults;
+  this.rules = block.normal;
 
-  tokens.links = {};
+  if (this.options.gfm) {
+    if (this.options.tables) {
+      this.rules = block.tables;
+    } else {
+      this.rules = block.gfm;
+    }
+  }
+}
 
-  src = src
-    .replace(/\r\n|\r/g, '\n')
-    .replace(/\t/g, '    ');
+/**
+ * Expose Block Rules
+ */
 
-  return block.token(src, tokens, true);
+Lexer.rules = block;
+
+/**
+ * Static Lex Method
+ */
+
+Lexer.lex = function(src, options) {
+  var lexer = new Lexer(options);
+  return lexer.lex(src);
 };
 
-block.token = function(src, tokens, top) {
+/**
+ * Preprocessing
+ */
+
+Lexer.prototype.lex = function(src) {
+  src = src
+    .replace(/\r\n|\r/g, '\n')
+    .replace(/\t/g, '    ')
+    .replace(/\u00a0/g, ' ')
+    .replace(/\u2424/g, '\n');
+
+  return this.token(src, true);
+};
+
+/**
+ * Lexing
+ */
+
+Lexer.prototype.token = function(src, top) {
   var src = src.replace(/^ +$/gm, '')
     , next
     , loose
     , cap
+    , bull
+    , b
     , item
     , space
     , i
@@ -104,22 +153,22 @@ block.token = function(src, tokens, top) {
 
   while (src) {
     // newline
-    if (cap = block.newline.exec(src)) {
+    if (cap = this.rules.newline.exec(src)) {
       src = src.substring(cap[0].length);
       if (cap[0].length > 1) {
-        tokens.push({
+        this.tokens.push({
           type: 'space'
         });
       }
     }
 
     // code
-    if (cap = block.code.exec(src)) {
+    if (cap = this.rules.code.exec(src)) {
       src = src.substring(cap[0].length);
       cap = cap[0].replace(/^ {4}/gm, '');
-      tokens.push({
+      this.tokens.push({
         type: 'code',
-        text: !options.pedantic
+        text: !this.options.pedantic
           ? cap.replace(/\n+$/, '')
           : cap
       });
@@ -127,20 +176,20 @@ block.token = function(src, tokens, top) {
     }
 
     // fences (gfm)
-    if (cap = block.fences.exec(src)) {
+    if (cap = this.rules.fences.exec(src)) {
       src = src.substring(cap[0].length);
-      tokens.push({
+      this.tokens.push({
         type: 'code',
-        lang: cap[1],
-        text: cap[2]
+        lang: cap[2],
+        text: cap[3]
       });
       continue;
     }
 
     // heading
-    if (cap = block.heading.exec(src)) {
+    if (cap = this.rules.heading.exec(src)) {
       src = src.substring(cap[0].length);
-      tokens.push({
+      this.tokens.push({
         type: 'heading',
         depth: cap[1].length,
         text: cap[2]
@@ -148,10 +197,42 @@ block.token = function(src, tokens, top) {
       continue;
     }
 
-    // lheading
-    if (cap = block.lheading.exec(src)) {
+    // table no leading pipe (gfm)
+    if (top && (cap = this.rules.nptable.exec(src))) {
       src = src.substring(cap[0].length);
-      tokens.push({
+
+      item = {
+        type: 'table',
+        header: cap[1].replace(/^ *| *\| *$/g, '').split(/ *\| */),
+        align: cap[2].replace(/^ *|\| *$/g, '').split(/ *\| */),
+        cells: cap[3].replace(/\n$/, '').split('\n')
+      };
+
+      for (i = 0; i < item.align.length; i++) {
+        if (/^ *-+: *$/.test(item.align[i])) {
+          item.align[i] = 'right';
+        } else if (/^ *:-+: *$/.test(item.align[i])) {
+          item.align[i] = 'center';
+        } else if (/^ *:-+ *$/.test(item.align[i])) {
+          item.align[i] = 'left';
+        } else {
+          item.align[i] = null;
+        }
+      }
+
+      for (i = 0; i < item.cells.length; i++) {
+        item.cells[i] = item.cells[i].split(/ *\| */);
+      }
+
+      this.tokens.push(item);
+
+      continue;
+    }
+
+    // lheading
+    if (cap = this.rules.lheading.exec(src)) {
+      src = src.substring(cap[0].length);
+      this.tokens.push({
         type: 'heading',
         depth: cap[2] === '=' ? 1 : 2,
         text: cap[1]
@@ -160,19 +241,19 @@ block.token = function(src, tokens, top) {
     }
 
     // hr
-    if (cap = block.hr.exec(src)) {
+    if (cap = this.rules.hr.exec(src)) {
       src = src.substring(cap[0].length);
-      tokens.push({
+      this.tokens.push({
         type: 'hr'
       });
       continue;
     }
 
     // blockquote
-    if (cap = block.blockquote.exec(src)) {
+    if (cap = this.rules.blockquote.exec(src)) {
       src = src.substring(cap[0].length);
 
-      tokens.push({
+      this.tokens.push({
         type: 'blockquote_start'
       });
 
@@ -181,9 +262,9 @@ block.token = function(src, tokens, top) {
       // Pass `top` to keep the current
       // "toplevel" state. This is exactly
       // how markdown.pl works.
-      block.token(cap, tokens, top);
+      this.token(cap, top);
 
-      tokens.push({
+      this.tokens.push({
         type: 'blockquote_end'
       });
 
@@ -191,16 +272,21 @@ block.token = function(src, tokens, top) {
     }
 
     // list
-    if (cap = block.list.exec(src)) {
+    if (cap = this.rules.list.exec(src)) {
       src = src.substring(cap[0].length);
 
-      tokens.push({
+      this.tokens.push({
         type: 'list_start',
         ordered: isFinite(cap[2])
       });
 
       // Get each top-level item.
-      cap = cap[0].match(block.item);
+      cap = cap[0].match(this.rules.item);
+
+      // Get bullet.
+      if (this.options.smartLists) {
+        bull = block.bullet.exec(cap[0])[0];
+      }
 
       next = false;
       l = cap.length;
@@ -218,9 +304,19 @@ block.token = function(src, tokens, top) {
         // list item contains. Hacky.
         if (~item.indexOf('\n ')) {
           space -= item.length;
-          item = !options.pedantic
+          item = !this.options.pedantic
             ? item.replace(new RegExp('^ {1,' + space + '}', 'gm'), '')
             : item.replace(/^ {1,4}/gm, '');
+        }
+
+        // Determine whether the next list item belongs here.
+        // Backpedal if it does not belong in this list.
+        if (this.options.smartLists && i !== l - 1) {
+          b = block.bullet.exec(cap[i+1])[0];
+          if (bull !== b && !(bull[1] === '.' && b[1] === '.')) {
+            src = cap.slice(i + 1).join('\n') + src;
+            i = l - 1;
+          }
         }
 
         // Determine whether item is loose or not.
@@ -232,21 +328,21 @@ block.token = function(src, tokens, top) {
           if (!loose) loose = next;
         }
 
-        tokens.push({
+        this.tokens.push({
           type: loose
             ? 'loose_item_start'
             : 'list_item_start'
         });
 
         // Recurse.
-        block.token(item, tokens);
+        this.token(item, false);
 
-        tokens.push({
+        this.tokens.push({
           type: 'list_item_end'
         });
       }
 
-      tokens.push({
+      this.tokens.push({
         type: 'list_end'
       });
 
@@ -254,10 +350,12 @@ block.token = function(src, tokens, top) {
     }
 
     // html
-    if (cap = block.html.exec(src)) {
+    if (cap = this.rules.html.exec(src)) {
       src = src.substring(cap[0].length);
-      tokens.push({
-        type: 'html',
+      this.tokens.push({
+        type: this.options.sanitize
+          ? 'paragraph'
+          : 'html',
         pre: cap[1] === 'pre',
         text: cap[0]
       });
@@ -265,95 +363,197 @@ block.token = function(src, tokens, top) {
     }
 
     // def
-    if (top && (cap = block.def.exec(src))) {
+    if (top && (cap = this.rules.def.exec(src))) {
       src = src.substring(cap[0].length);
-      tokens.links[cap[1].toLowerCase()] = {
+      this.tokens.links[cap[1].toLowerCase()] = {
         href: cap[2],
         title: cap[3]
       };
       continue;
     }
 
-    // top-level paragraph
-    if (top && (cap = block.paragraph.exec(src))) {
+    // table (gfm)
+    if (top && (cap = this.rules.table.exec(src))) {
       src = src.substring(cap[0].length);
-      tokens.push({
+
+      item = {
+        type: 'table',
+        header: cap[1].replace(/^ *| *\| *$/g, '').split(/ *\| */),
+        align: cap[2].replace(/^ *|\| *$/g, '').split(/ *\| */),
+        cells: cap[3].replace(/(?: *\| *)?\n$/, '').split('\n')
+      };
+
+      for (i = 0; i < item.align.length; i++) {
+        if (/^ *-+: *$/.test(item.align[i])) {
+          item.align[i] = 'right';
+        } else if (/^ *:-+: *$/.test(item.align[i])) {
+          item.align[i] = 'center';
+        } else if (/^ *:-+ *$/.test(item.align[i])) {
+          item.align[i] = 'left';
+        } else {
+          item.align[i] = null;
+        }
+      }
+
+      for (i = 0; i < item.cells.length; i++) {
+        item.cells[i] = item.cells[i]
+          .replace(/^ *\| *| *\| *$/g, '')
+          .split(/ *\| */);
+      }
+
+      this.tokens.push(item);
+
+      continue;
+    }
+
+    // top-level paragraph
+    if (top && (cap = this.rules.paragraph.exec(src))) {
+      src = src.substring(cap[0].length);
+      this.tokens.push({
         type: 'paragraph',
-        text: cap[0]
+        text: cap[1][cap[1].length-1] === '\n'
+          ? cap[1].slice(0, -1)
+          : cap[1]
       });
       continue;
     }
 
     // text
-    if (cap = block.text.exec(src)) {
+    if (cap = this.rules.text.exec(src)) {
       // Top-level should never reach here.
       src = src.substring(cap[0].length);
-      tokens.push({
+      this.tokens.push({
         type: 'text',
         text: cap[0]
       });
       continue;
     }
+
+    if (src) {
+      throw new
+        Error('Infinite loop on byte: ' + src.charCodeAt(0));
+    }
   }
 
-  return tokens;
+  return this.tokens;
 };
 
 /**
- * Inline Processing
+ * Inline-Level Grammar
  */
 
 var inline = {
   escape: /^\\([\\`*{}\[\]()#+\-.!_>])/,
   autolink: /^<([^ >]+(@|:\/)[^ >]+)>/,
   url: noop,
-  tag: /^<!--[^\0]*?-->|^<\/?\w+(?:"[^"]*"|'[^']*'|[^'">])*?>/,
+  tag: /^<!--[\s\S]*?-->|^<\/?\w+(?:"[^"]*"|'[^']*'|[^'">])*?>/,
   link: /^!?\[(inside)\]\(href\)/,
   reflink: /^!?\[(inside)\]\s*\[([^\]]*)\]/,
   nolink: /^!?\[((?:\[[^\]]*\]|[^\[\]])*)\]/,
-  strong: /^__([^\0]+?)__(?!_)|^\*\*([^\0]+?)\*\*(?!\*)/,
-  em: /^\b_((?:__|[^\0])+?)_\b|^\*((?:\*\*|[^\0])+?)\*(?!\*)/,
-  code: /^(`+)([^\0]*?[^`])\1(?!`)/,
+  strong: /^__([\s\S]+?)__(?!_)|^\*\*([\s\S]+?)\*\*(?!\*)/,
+  em: /^\b_((?:__|[\s\S])+?)_\b|^\*((?:\*\*|[\s\S])+?)\*(?!\*)/,
+  code: /^(`+)\s*([\s\S]*?[^`])\s*\1(?!`)/,
   br: /^ {2,}\n(?!\s*$)/,
-  text: /^[^\0]+?(?=[\\<!\[_*`]| {2,}\n|$)/
+  del: noop,
+  text: /^[\s\S]+?(?=[\\<!\[_*`]| {2,}\n|$)/
 };
 
-inline._linkInside = /(?:\[[^\]]*\]|[^\]]|\](?=[^\[]*\]))*/;
-inline._linkHref = /\s*<?([^\s]*?)>?(?:\s+['"]([^\0]*?)['"])?\s*/;
+inline._inside = /(?:\[[^\]]*\]|[^\]]|\](?=[^\[]*\]))*/;
+inline._href = /\s*<?([^\s]*?)>?(?:\s+['"]([\s\S]*?)['"])?\s*/;
 
 inline.link = replace(inline.link)
-  ('inside', inline._linkInside)
-  ('href', inline._linkHref)
+  ('inside', inline._inside)
+  ('href', inline._href)
   ();
 
 inline.reflink = replace(inline.reflink)
-  ('inside', inline._linkInside)
+  ('inside', inline._inside)
   ();
 
-inline.normal = {
-  url: inline.url,
-  strong: inline.strong,
-  em: inline.em,
-  text: inline.text
-};
+/**
+ * Normal Inline Grammar
+ */
 
-inline.pedantic = {
-  strong: /^__(?=\S)([^\0]*?\S)__(?!_)|^\*\*(?=\S)([^\0]*?\S)\*\*(?!\*)/,
-  em: /^_(?=\S)([^\0]*?\S)_(?!_)|^\*(?=\S)([^\0]*?\S)\*(?!\*)/
-};
+inline.normal = merge({}, inline);
 
-inline.gfm = {
-  url: /^(https?:\/\/[^\s]+[^.,:;"')\]\s])/,
-  text: /^[^\0]+?(?=[\\<!\[_*`]|https?:\/\/| {2,}\n|$)/
+/**
+ * Pedantic Inline Grammar
+ */
+
+inline.pedantic = merge({}, inline.normal, {
+  strong: /^__(?=\S)([\s\S]*?\S)__(?!_)|^\*\*(?=\S)([\s\S]*?\S)\*\*(?!\*)/,
+  em: /^_(?=\S)([\s\S]*?\S)_(?!_)|^\*(?=\S)([\s\S]*?\S)\*(?!\*)/
+});
+
+/**
+ * GFM Inline Grammar
+ */
+
+inline.gfm = merge({}, inline.normal, {
+  escape: replace(inline.escape)('])', '~|])')(),
+  url: /^(https?:\/\/[^\s<]+[^<.,:;"')\]\s])/,
+  del: /^~~(?=\S)([\s\S]*?\S)~~/,
+  text: replace(inline.text)
+    (']|', '~]|')
+    ('|', '|https?://|')
+    ()
+});
+
+/**
+ * GFM + Line Breaks Inline Grammar
+ */
+
+inline.breaks = merge({}, inline.gfm, {
+  br: replace(inline.br)('{2,}', '*')(),
+  text: replace(inline.gfm.text)('{2,}', '*')()
+});
+
+/**
+ * Inline Lexer & Compiler
+ */
+
+function InlineLexer(links, options) {
+  this.options = options || marked.defaults;
+  this.links = links;
+  this.rules = inline.normal;
+
+  if (!this.links) {
+    throw new
+      Error('Tokens array requires a `links` property.');
+  }
+
+  if (this.options.gfm) {
+    if (this.options.breaks) {
+      this.rules = inline.breaks;
+    } else {
+      this.rules = inline.gfm;
+    }
+  } else if (this.options.pedantic) {
+    this.rules = inline.pedantic;
+  }
+}
+
+/**
+ * Expose Inline Rules
+ */
+
+InlineLexer.rules = inline;
+
+/**
+ * Static Lexing/Compiling Method
+ */
+
+InlineLexer.output = function(src, links, options) {
+  var inline = new InlineLexer(links, options);
+  return inline.output(src);
 };
 
 /**
- * Inline Lexer
+ * Lexing/Compiling
  */
 
-inline.lexer = function(src) {
+InlineLexer.prototype.output = function(src) {
   var out = ''
-    , links = tokens.links
     , link
     , text
     , href
@@ -361,20 +561,20 @@ inline.lexer = function(src) {
 
   while (src) {
     // escape
-    if (cap = inline.escape.exec(src)) {
+    if (cap = this.rules.escape.exec(src)) {
       src = src.substring(cap[0].length);
       out += cap[1];
       continue;
     }
 
     // autolink
-    if (cap = inline.autolink.exec(src)) {
+    if (cap = this.rules.autolink.exec(src)) {
       src = src.substring(cap[0].length);
       if (cap[2] === '@') {
         text = cap[1][6] === ':'
-          ? mangle(cap[1].substring(7))
-          : mangle(cap[1]);
-        href = mangle('mailto:') + text;
+          ? this.mangle(cap[1].substring(7))
+          : this.mangle(cap[1]);
+        href = this.mangle('mailto:') + text;
       } else {
         text = escape(cap[1]);
         href = text;
@@ -388,7 +588,7 @@ inline.lexer = function(src) {
     }
 
     // url (gfm)
-    if (cap = inline.url.exec(src)) {
+    if (cap = this.rules.url.exec(src)) {
       src = src.substring(cap[0].length);
       text = escape(cap[1]);
       href = text;
@@ -401,18 +601,18 @@ inline.lexer = function(src) {
     }
 
     // tag
-    if (cap = inline.tag.exec(src)) {
+    if (cap = this.rules.tag.exec(src)) {
       src = src.substring(cap[0].length);
-      out += options.sanitize
+      out += this.options.sanitize
         ? escape(cap[0])
         : cap[0];
       continue;
     }
 
     // link
-    if (cap = inline.link.exec(src)) {
+    if (cap = this.rules.link.exec(src)) {
       src = src.substring(cap[0].length);
-      out += outputLink(cap, {
+      out += this.outputLink(cap, {
         href: cap[2],
         title: cap[3]
       });
@@ -420,40 +620,40 @@ inline.lexer = function(src) {
     }
 
     // reflink, nolink
-    if ((cap = inline.reflink.exec(src))
-        || (cap = inline.nolink.exec(src))) {
+    if ((cap = this.rules.reflink.exec(src))
+        || (cap = this.rules.nolink.exec(src))) {
       src = src.substring(cap[0].length);
       link = (cap[2] || cap[1]).replace(/\s+/g, ' ');
-      link = links[link.toLowerCase()];
+      link = this.links[link.toLowerCase()];
       if (!link || !link.href) {
         out += cap[0][0];
         src = cap[0].substring(1) + src;
         continue;
       }
-      out += outputLink(cap, link);
+      out += this.outputLink(cap, link);
       continue;
     }
 
     // strong
-    if (cap = inline.strong.exec(src)) {
+    if (cap = this.rules.strong.exec(src)) {
       src = src.substring(cap[0].length);
       out += '<strong>'
-        + inline.lexer(cap[2] || cap[1])
+        + this.output(cap[2] || cap[1])
         + '</strong>';
       continue;
     }
 
     // em
-    if (cap = inline.em.exec(src)) {
+    if (cap = this.rules.em.exec(src)) {
       src = src.substring(cap[0].length);
       out += '<em>'
-        + inline.lexer(cap[2] || cap[1])
+        + this.output(cap[2] || cap[1])
         + '</em>';
       continue;
     }
 
     // code
-    if (cap = inline.code.exec(src)) {
+    if (cap = this.rules.code.exec(src)) {
       src = src.substring(cap[0].length);
       out += '<code>'
         + escape(cap[2], true)
@@ -462,24 +662,42 @@ inline.lexer = function(src) {
     }
 
     // br
-    if (cap = inline.br.exec(src)) {
+    if (cap = this.rules.br.exec(src)) {
       src = src.substring(cap[0].length);
       out += '<br>';
       continue;
     }
 
+    // del (gfm)
+    if (cap = this.rules.del.exec(src)) {
+      src = src.substring(cap[0].length);
+      out += '<del>'
+        + this.output(cap[1])
+        + '</del>';
+      continue;
+    }
+
     // text
-    if (cap = inline.text.exec(src)) {
+    if (cap = this.rules.text.exec(src)) {
       src = src.substring(cap[0].length);
       out += escape(cap[0]);
       continue;
+    }
+
+    if (src) {
+      throw new
+        Error('Infinite loop on byte: ' + src.charCodeAt(0));
     }
   }
 
   return out;
 };
 
-function outputLink(cap, link) {
+/**
+ * Compile Link
+ */
+
+InlineLexer.prototype.outputLink = function(cap, link) {
   if (cap[0][0] !== '!') {
     return '<a href="'
       + escape(link.href)
@@ -490,7 +708,7 @@ function outputLink(cap, link) {
       + '"'
       : '')
       + '>'
-      + inline.lexer(cap[1])
+      + this.output(cap[1])
       + '</a>';
   } else {
     return '<img src="'
@@ -505,171 +723,13 @@ function outputLink(cap, link) {
       : '')
       + '>';
   }
-}
+};
 
 /**
- * Parsing
+ * Mangle Links
  */
 
-var tokens
-  , token;
-
-function next() {
-  return token = tokens.pop();
-}
-
-function tok() {
-  
-  switch (token.type) {
-    case 'space': {
-      return '';
-    }
-    case 'hr': {
-      return '<hr>\n';
-    }
-    case 'heading': {
-      return '<h'
-        + token.depth
-        + '>'
-        + inline.lexer(token.text)
-        + '</h'
-        + token.depth
-        + '>\n';
-    }
-    case 'code': {
-      if (options.highlight) {
-        token.code = options.highlight(token.text, token.lang);
-        if (token.code != null && token.code !== token.text) {
-          token.escaped = true;
-          token.text = token.code;
-        }
-      }
-
-      if (!token.escaped) {
-        token.text = escape(token.text, true);
-      }
-
-      return '<pre><code'
-        + (token.lang
-        ? ' class="lang-'
-        + token.lang
-        + '"'
-        : '')
-        + '>'
-        + token.text
-        + '</code></pre>\n';
-    }
-    case 'blockquote_start': {
-      var body = '';
-
-      while (next().type !== 'blockquote_end') {
-        body += tok();
-      }
-
-      return '<blockquote>\n'
-        + body
-        + '</blockquote>\n';
-    }
-    case 'list_start': {
-      var type = token.ordered ? 'ol' : 'ul'
-        , body = '';
-      while (next().type !== 'list_end') {
-        body += tok();
-      }
-
-      return '<'
-        + type
-        + '>\n'
-        + body
-        + '</'
-        + type
-        + '>\n';
-    }
-    case 'list_item_start': {
-      var body = '';
-
-      while (next().type !== 'list_item_end') {
-        body += token.type === 'text'
-          ? parseText()
-          : tok();
-      }
-
-      return '<li>'
-        + body
-        + '</li>\n';
-    }
-    case 'loose_item_start': {
-      var body = '';
-
-      while (next().type !== 'list_item_end') {
-        body += tok();
-      }
-
-      return '<li>'
-        + body
-        + '</li>\n';
-    }
-    case 'html': {
-      if (options.sanitize) {
-        return inline.lexer(token.text);
-      }
-      return !token.pre && !options.pedantic
-        ? inline.lexer(token.text)
-        : token.text;
-    }
-    case 'paragraph': {
-      return '<p>'
-        + inline.lexer(token.text)
-        + '</p>\n';
-    }
-    case 'text': {
-      return '<p>'
-        + parseText()
-        + '</p>\n';
-    }
-  }
-}
-
-function parseText() {
-  var body = token.text
-    , top;
-
-  while ((top = tokens[tokens.length-1])
-         && top.type === 'text') {
-    body += '\n' + next().text;
-  }
-
-  return inline.lexer(body);
-}
-
-function parse(src) {
-  tokens = src.reverse();
-
-  var out = '';
-  while (next()) {
-    out += tok();
-  }
-
-  tokens = null;
-  token = null;
-
-  return out;
-}
-
-/**
- * Helpers
- */
-
-function escape(html, encode) {
-  return html
-    .replace(!encode ? /&(?!#?\w+;)/g : /&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;');
-}
-
-function mangle(text) {
+InlineLexer.prototype.mangle = function(text) {
   var out = ''
     , l = text.length
     , i = 0
@@ -684,15 +744,235 @@ function mangle(text) {
   }
 
   return out;
+};
+
+/**
+ * Parsing & Compiling
+ */
+
+function Parser(options) {
+  this.tokens = [];
+  this.token = null;
+  this.options = options || marked.defaults;
 }
 
-function tag() {
-  var tag = '(?!(?:'
-    + 'a|em|strong|small|s|cite|q|dfn|abbr|data|time|code'
-    + '|var|samp|kbd|sub|sup|i|b|u|mark|ruby|rt|rp|bdi|bdo'
-    + '|span|br|wbr|ins|del|img)\\b)\\w+';
+/**
+ * Static Parse Method
+ */
 
-  return tag;
+Parser.parse = function(src, options) {
+  var parser = new Parser(options);
+  return parser.parse(src);
+};
+
+/**
+ * Parse Loop
+ */
+
+Parser.prototype.parse = function(src) {
+  this.inline = new InlineLexer(src.links, this.options);
+  this.tokens = src.reverse();
+
+  var out = '';
+  while (this.next()) {
+    out += this.tok();
+  }
+
+  return out;
+};
+
+/**
+ * Next Token
+ */
+
+Parser.prototype.next = function() {
+  return this.token = this.tokens.pop();
+};
+
+/**
+ * Preview Next Token
+ */
+
+Parser.prototype.peek = function() {
+  return this.tokens[this.tokens.length-1] || 0;
+};
+
+/**
+ * Parse Text Tokens
+ */
+
+Parser.prototype.parseText = function() {
+  var body = this.token.text;
+
+  while (this.peek().type === 'text') {
+    body += '\n' + this.next().text;
+  }
+
+  return this.inline.output(body);
+};
+
+/**
+ * Parse Current Token
+ */
+
+Parser.prototype.tok = function() {
+  switch (this.token.type) {
+    case 'space': {
+      return '';
+    }
+    case 'hr': {
+      return '<hr>\n';
+    }
+    case 'heading': {
+      return '<h'
+        + this.token.depth
+        + '>'
+        + this.inline.output(this.token.text)
+        + '</h'
+        + this.token.depth
+        + '>\n';
+    }
+    case 'code': {
+      if (this.options.highlight) {
+        var code = this.options.highlight(this.token.text, this.token.lang);
+        if (code != null && code !== this.token.text) {
+          this.token.escaped = true;
+          this.token.text = code;
+        }
+      }
+
+      if (!this.token.escaped) {
+        this.token.text = escape(this.token.text, true);
+      }
+
+      return '<pre><code'
+        + (this.token.lang
+        ? ' class="'
+        + this.options.langPrefix
+        + this.token.lang
+        + '"'
+        : '')
+        + '>'
+        + this.token.text
+        + '</code></pre>\n';
+    }
+    case 'table': {
+      var body = ''
+        , heading
+        , i
+        , row
+        , cell
+        , j;
+
+      // header
+      body += '<thead>\n<tr>\n';
+      for (i = 0; i < this.token.header.length; i++) {
+        heading = this.inline.output(this.token.header[i]);
+        body += this.token.align[i]
+          ? '<th align="' + this.token.align[i] + '">' + heading + '</th>\n'
+          : '<th>' + heading + '</th>\n';
+      }
+      body += '</tr>\n</thead>\n';
+
+      // body
+      body += '<tbody>\n'
+      for (i = 0; i < this.token.cells.length; i++) {
+        row = this.token.cells[i];
+        body += '<tr>\n';
+        for (j = 0; j < row.length; j++) {
+          cell = this.inline.output(row[j]);
+          body += this.token.align[j]
+            ? '<td align="' + this.token.align[j] + '">' + cell + '</td>\n'
+            : '<td>' + cell + '</td>\n';
+        }
+        body += '</tr>\n';
+      }
+      body += '</tbody>\n';
+
+      return '<table>\n'
+        + body
+        + '</table>\n';
+    }
+    case 'blockquote_start': {
+      var body = '';
+
+      while (this.next().type !== 'blockquote_end') {
+        body += this.tok();
+      }
+
+      return '<blockquote>\n'
+        + body
+        + '</blockquote>\n';
+    }
+    case 'list_start': {
+      var type = this.token.ordered ? 'ol' : 'ul'
+        , body = '';
+
+      while (this.next().type !== 'list_end') {
+        body += this.tok();
+      }
+
+      return '<'
+        + type
+        + '>\n'
+        + body
+        + '</'
+        + type
+        + '>\n';
+    }
+    case 'list_item_start': {
+      var body = '';
+
+      while (this.next().type !== 'list_item_end') {
+        body += this.token.type === 'text'
+          ? this.parseText()
+          : this.tok();
+      }
+
+      return '<li>'
+        + body
+        + '</li>\n';
+    }
+    case 'loose_item_start': {
+      var body = '';
+
+      while (this.next().type !== 'list_item_end') {
+        body += this.tok();
+      }
+
+      return '<li>'
+        + body
+        + '</li>\n';
+    }
+    case 'html': {
+      return !this.token.pre && !this.options.pedantic
+        ? this.inline.output(this.token.text)
+        : this.token.text;
+    }
+    case 'paragraph': {
+      return '<p>'
+        + this.inline.output(this.token.text)
+        + '</p>\n';
+    }
+    case 'text': {
+      return '<p>'
+        + this.parseText()
+        + '</p>\n';
+    }
+  }
+};
+
+/**
+ * Helpers
+ */
+
+function escape(html, encode) {
+  return html
+    .replace(!encode ? /&(?!#?\w+;)/g : /&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
 }
 
 function replace(regex, opt) {
@@ -700,7 +980,9 @@ function replace(regex, opt) {
   opt = opt || '';
   return function self(name, val) {
     if (!name) return new RegExp(regex, opt);
-    regex = regex.replace(name, val.source || val);
+    val = val.source || val;
+    val = val.replace(/(^|[^\[])\^/g, '$1');
+    regex = regex.replace(name, val);
     return self;
   };
 }
@@ -708,80 +990,83 @@ function replace(regex, opt) {
 function noop() {}
 noop.exec = noop;
 
+function merge(obj) {
+  var i = 1
+    , target
+    , key;
+
+  for (; i < arguments.length; i++) {
+    target = arguments[i];
+    for (key in target) {
+      if (Object.prototype.hasOwnProperty.call(target, key)) {
+        obj[key] = target[key];
+      }
+    }
+  }
+
+  return obj;
+}
+
 /**
  * Marked
  */
 
 function marked(src, opt) {
-  setOptions(opt);
-  return parse(block.lexer(src));
+  try {
+    if (opt) opt = merge({}, marked.defaults, opt);
+    return Parser.parse(Lexer.lex(src, opt), opt);
+  } catch (e) {
+    e.message += '\nPlease report this to https://github.com/chjj/marked.';
+    if ((opt || marked.defaults).silent) {
+      return '<p>An error occured:</p><pre>'
+        + escape(e.message + '', true)
+        + '</pre>';
+    }
+    throw e;
+  }
 }
 
 /**
  * Options
  */
 
-var options
-  , defaults;
-
-function setOptions(opt) {
-  if (!opt) opt = defaults;
-  if (options === opt) return;
-  options = opt;
-
-  if (options.gfm) {
-    block.fences = block.gfm.fences;
-    block.paragraph = block.gfm.paragraph;
-    inline.text = inline.gfm.text;
-    inline.url = inline.gfm.url;
-  } else {
-    block.fences = block.normal.fences;
-    block.paragraph = block.normal.paragraph;
-    inline.text = inline.normal.text;
-    inline.url = inline.normal.url;
-  }
-
-  if (options.pedantic) {
-    inline.em = inline.pedantic.em;
-    inline.strong = inline.pedantic.strong;
-  } else {
-    inline.em = inline.normal.em;
-    inline.strong = inline.normal.strong;
-  }
-}
-
 marked.options =
 marked.setOptions = function(opt) {
-  defaults = opt;
-  setOptions(opt);
+  merge(marked.defaults, opt);
   return marked;
 };
 
-marked.setOptions({
+marked.defaults = {
   gfm: true,
+  tables: true,
+  breaks: false,
   pedantic: false,
   sanitize: false,
-  highlight: null
-});
+  smartLists: false,
+  silent: false,
+  highlight: null,
+  langPrefix: 'lang-'
+};
 
 /**
  * Expose
  */
 
-marked.parser = function(src, opt) {
-  setOptions(opt);
-  return parse(src);
-};
+marked.Parser = Parser;
+marked.parser = Parser.parse;
 
-marked.lexer = function(src, opt) {
-  setOptions(opt);
-  return block.lexer(src);
-};
+marked.Lexer = Lexer;
+marked.lexer = Lexer.lex;
+
+marked.InlineLexer = InlineLexer;
+marked.inlineLexer = InlineLexer.output;
 
 marked.parse = marked;
 
-if (typeof module !== 'undefined') {
+if (typeof exports === 'object') {
   module.exports = marked;
+} else if (typeof define === 'function' && define.amd) {
+  define(function() { return marked; });
 } else {
   this.marked = marked;
 }
@@ -789,5 +1074,3 @@ if (typeof module !== 'undefined') {
 }).call(function() {
   return this || (typeof window !== 'undefined' ? window : global);
 }());
-return marked;
-});

--- a/js/views/style/menu.js
+++ b/js/views/style/menu.js
@@ -6,7 +6,7 @@ define([
   'jscssp',
   'config',
   'libs/marked/marked',
-], function($, _, Backbone, dashboardPageTemplate, jscssp, config){
+], function($, _, Backbone, dashboardPageTemplate, jscssp, config, marked){
   var DashboardPage = Backbone.View.extend({
     el: '.kalei-style-menu',
     render: function () {   
@@ -17,9 +17,10 @@ define([
 
       var masterStyle = config.css_path.substr(config.css_path.lastIndexOf('/')+1);
         
+      var markedOpts = _.extend({ sanitize: false, gfm: true }, config.marked_options || {});
      
       var parser = new jscssp();
-        marked.setOptions({ sanitize: false, gfm: true });
+        marked.setOptions(markedOpts);
         var stylesheet = parser.parse(styles, false, true);
         var menus = [];
         var menuTitle = '';

--- a/js/views/style/menu.js
+++ b/js/views/style/menu.js
@@ -37,15 +37,18 @@ define([
             comment = comment.replace('*/', '');
 
             var comments = marked.lexer(comment);
+            var defLinks = comments.links || {};
             _.each(comments, function (comment) {
+              var tokens = [comment];
+              tokens.links = defLinks;
               
               if(comment.type === 'heading' && comment.depth === 1) {
-                menuTitle = marked.parser([comment]);
+                menuTitle = marked.parser(tokens);
               }
               if(comment.type === 'heading' && comment.depth === 3) {
                 menus.push(_.extend({}, currentMenu));
                 currentMenu.sheets = [];
-                currentMenu.category = marked.parser([comment]);
+                currentMenu.category = marked.parser(tokens);
               }
 
             });

--- a/js/views/style/menu.js
+++ b/js/views/style/menu.js
@@ -5,11 +5,11 @@ define([
   'text!templates/style/menu.html',
   'jscssp',
   'config',
-  'libs/marked/marked',
+  'libs/marked/marked'
 ], function($, _, Backbone, dashboardPageTemplate, jscssp, config, marked){
   var DashboardPage = Backbone.View.extend({
     el: '.kalei-style-menu',
-    render: function () {   
+    render: function () {
       var that = this;
       that.$el.html('Loading styles');
       console.log(config.css_path);

--- a/js/views/style/page.js
+++ b/js/views/style/page.js
@@ -44,6 +44,7 @@ define([
         var stylesheet = parser.parse(stylesheet, false, true);
         var blocks = [];
         var currentBlock = {
+          links: {},
           comments: [],
           css: ''
 
@@ -51,14 +52,16 @@ define([
         var headings = [];
 
         _.each(stylesheet.cssRules, function(rule) {
-    			if(rule.type === 101) {
-    			  var comment = rule.parsedCssText;
+          if(rule.type === 101) {
+            var comment = rule.parsedCssText;
             comment = comment.replace('/*', '');
             comment = comment.replace('*/', '');
             var comments = marked.lexer(comment);
+            var defLinks = comments.links || {}; // lexer appends definition links to returned token object
+            currentBlock.comments.links = defLinks;
+
             _.each(comments, function (comment) {
-
-
+              
               if(comment.type === 'heading' && comment.depth <= 2) {
                 headings.push(comment.text);
                 currentBlock.css = css_beautify(currentBlock.css);
@@ -66,6 +69,7 @@ define([
                   currentBlock.comments = marked.parser(currentBlock.comments);
                   blocks.push(_.extend({}, currentBlock));
                   currentBlock.comments = [];
+                  currentBlock.comments.links = defLinks;
                   currentBlock.css = '';
                 }
               }
@@ -79,7 +83,7 @@ define([
             
             });
 
-    			}
+          }
           if(rule.type === 1) {
             currentBlock.css += rule.parsedCssText;
 
@@ -93,7 +97,7 @@ define([
 
           }
 
-		    });
+        });
       $('.sheet-submenu').slideUp(200);
         currentBlock.css = css_beautify(currentBlock.css);
         var submenu = $('<ul>');

--- a/js/views/style/page.js
+++ b/js/views/style/page.js
@@ -22,6 +22,7 @@ define([
         }
       $('head').append('<link rel="stylesheet" href="' + config.css_path + '"" type="text/css" />');
       var converter = new Pagedown.Converter();
+      var markedOpts = _.extend({ sanitize: false, gfm: true }, config.marked_options || {});
       var that = this;
       var styleUrl;
       if(this.options.style === null) {
@@ -37,9 +38,9 @@ define([
         styleUrl = configDir + '/' + this.options.style;
       }
       console.log('try', styleUrl)
-		 require(['text!'+ styleUrl], function (stylesheet){
+     require(['text!'+ styleUrl], function (stylesheet){
         var parser = new jscssp();
-        marked.setOptions({ sanitize: false, gfm: true });
+        marked.setOptions(markedOpts);
         var stylesheet = parser.parse(stylesheet, false, true);
         var blocks = [];
         var currentBlock = {

--- a/js/views/style/page.js
+++ b/js/views/style/page.js
@@ -23,25 +23,25 @@ define([
       $('head').append('<link rel="stylesheet" href="' + config.css_path + '"" type="text/css" />');
       var converter = new Pagedown.Converter();
       var markedOpts = _.extend({ sanitize: false, gfm: true }, config.marked_options || {});
-      var that = this;
       var styleUrl;
+      var configDir;
       if(this.options.style === null) {
         this.options.style = config.css_path.substr(config.css_path.lastIndexOf('/')+1);
       }
       if(this.options.style.substr(0,1) === '/') {
         // non relative
-        var configDir = config.css_path.substr(0, config.css_path.lastIndexOf('/'));
+        configDir = config.css_path.substr(0, config.css_path.lastIndexOf('/'));
         var pUrl = parseuri(configDir);
         styleUrl = pUrl.protocol + '://' + pUrl.host + (pUrl.port === '' ? '' : ':'+ pUrl) + this.options.style;
       } else {
-        var configDir = config.css_path.substr(0, config.css_path.lastIndexOf('/'));
+        configDir = config.css_path.substr(0, config.css_path.lastIndexOf('/'));
         styleUrl = configDir + '/' + this.options.style;
       }
-      console.log('try', styleUrl)
+      console.log('try', styleUrl);
      require(['text!'+ styleUrl], function (stylesheet){
         var parser = new jscssp();
         marked.setOptions(markedOpts);
-        var stylesheet = parser.parse(stylesheet, false, true);
+        stylesheet = parser.parse(stylesheet, false, true);
         var blocks = [];
         var currentBlock = {
           links: {},
@@ -77,8 +77,8 @@ define([
                 currentBlock.comments.push({
                   type: 'html',
                   text: '<div class="codedemo">' + comment.text + '<div style="clear: both;"></div></div>'
-                })
-              };
+                });
+              }
               currentBlock.comments.push(comment);
             
             });
@@ -121,12 +121,12 @@ define([
 
         $("body").on('click', '.sheet-submenu li', function(ev) {
 
-             $('html, body').animate({
-                 scrollTop: $(".kalei-comments h2:contains('"+$(ev.currentTarget).text()+"'),.kalei-comments h1:contains('"+$(ev.currentTarget).text()+"')").offset().top - 20
-             }, 200);
-         });
+          $('html, body').animate({
+            scrollTop: $(".kalei-comments h2:contains('"+$(ev.currentTarget).text()+"'),.kalei-comments h1:contains('"+$(ev.currentTarget).text()+"')").offset().top - 20
+          }, 200);
+        });
 
-         fixie.init();
+        fixie.init();
         
       });
 


### PR DESCRIPTION
Thanks for putting together such a great project and taking the time to share it.

I want to use tables in my style-guide documentation, which the current version of marked.js supports. Upgrading marked.js required the following:
- an update to marked.js v.0.2.8
- additional configuration that allows setting markdown options
- changes to the comment parsing to support changes to marked.js lexer / parse methods

The changes made to comment parsing were required because of a change to marked.js that broke kalei comment processing.

The token array returned by `marked.lexer` now includes a `links` property which is a hash of definition links defined within the markdown block. The `marked.parser` expects the `src` argument to be a token array with a `links` property. Since we process each token in the token list separately it is necessary to append a reference to the `links` property to each token item.
