### PR TITLE
http://www.fixiejs.com/ is no longer the website for fixiejs

### DIFF
--- a/css/fixie-demo.css
+++ b/css/fixie-demo.css
@@ -1,7 +1,7 @@
 /*
 # Fixie Example Usage
 
-[fixie.js](http://fixiejs.com/) is bundled with Kalei.
+[fixie.js](https://github.com/ryhan/fixie) is bundled with Kalei.
 
 "Just set class to fixie wherever you need dummy content. It works for headers, paragraphs, lists, images, and just about anything else."
 

--- a/css/styles.css
+++ b/css/styles.css
@@ -101,7 +101,7 @@ Kalei is heavily influenced by the following projects and blog posts.
 * [jscssp](http://www.glazman.org/JSCSSP/)
 * [LESS](http://lesscss.org/)
 * cssbeautify
-* [fixie](http://fixiejs.com/)
+* [fixie](https://github.com/ryhan/fixie)
 * [highlight](http://softwaremaniacs.org/soft/highlight/en/)
 * [backbone](http://backbonejs.org/)
 * [underscore](http://underscorejs.org/)


### PR DESCRIPTION
Change the link to https://github.com/ryhan/fixie instead of the Japanese diet website (http://www.fixiejs.com/).
